### PR TITLE
Upgrade semver to 6.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@actions/io": "1.1.2",
         "@actions/tool-cache": "2.0.1",
         "@hashicorp/github-actions-core": "github:hashicorp/github-actions-core#v0.3.0",
-        "@vercel/ncc": "0.36.1"
+        "@vercel/ncc": "0.36.1",
+        "semver": "^6.3.1"
       },
       "devDependencies": {
         "@types/node": "18.14.1",
@@ -307,9 +308,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -584,9 +585,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "version": "6.3.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
     },
     "tunnel": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "@actions/io": "1.1.2",
     "@actions/tool-cache": "2.0.1",
     "@hashicorp/github-actions-core": "github:hashicorp/github-actions-core#v0.3.0",
-    "@vercel/ncc": "0.36.1"
+    "@vercel/ncc": "0.36.1",
+    "semver": "^6.3.1"
   },
   "devDependencies": {
     "@types/node": "18.14.1",


### PR DESCRIPTION
# Summary

- bumps the package.json and package-lock.json for semver
- upgrade semver to 6.3.1
- mitigate https://security.snyk.io/vuln/SNYK-JS-SEMVER-3247795
- closes https://github.com/hashicorp/setup-packer/pull/82