### PR TITLE
feat: update action runner to use NodeJS 20

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 18.x
+          - 20.x
 
     steps:
       - name: Checkout Repository

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ outputs:
   version:
     description: "The Packer version that was installed and added to PATH."
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 branding:
   icon: "package"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-packer",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-packer",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "1.10.1",
@@ -16,7 +16,7 @@
         "@vercel/ncc": "0.36.1"
       },
       "devDependencies": {
-        "@types/node": "18.14.1",
+        "@types/node": "^20.11.10",
         "@types/semver": "7.5.4",
         "prettier": "2.8.4",
         "typescript": "4.9.5"
@@ -136,10 +136,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.1.tgz",
-      "integrity": "sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==",
-      "dev": true
+      "version": "20.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
+      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.4",
@@ -355,6 +358,12 @@
         "node": ">=14.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -479,10 +488,13 @@
       }
     },
     "@types/node": {
-      "version": "18.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.1.tgz",
-      "integrity": "sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==",
-      "dev": true
+      "version": "20.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
+      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/semver": {
       "version": "7.5.4",
@@ -632,6 +644,12 @@
       "requires": {
         "@fastify/busboy": "^2.0.0"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "uuid": {
       "version": "8.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-packer",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-packer",
-      "version": "2.2.0",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "1.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-packer",
-  "version": "3.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-packer",
-      "version": "3.0.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-packer",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "A GitHub Action to install a specific version of HashiCorp Packer and add it to PATH.",
   "keywords": [
     "github-actions",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-packer",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A GitHub Action to install a specific version of HashiCorp Packer and add it to PATH.",
   "keywords": [
     "github-actions",
@@ -26,7 +26,7 @@
     "@vercel/ncc": "0.36.1"
   },
   "devDependencies": {
-    "@types/node": "18.14.1",
+    "@types/node": "^20.11.10",
     "@types/semver": "7.5.4",
     "prettier": "2.8.4",
     "typescript": "4.9.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-packer",
-  "version": "3.0.0",
+  "version": "2.1.0",
   "description": "A GitHub Action to install a specific version of HashiCorp Packer and add it to PATH.",
   "keywords": [
     "github-actions",


### PR DESCRIPTION
Close #89 

> [!Note]
> https://github.blog/changelog/2022-05-20-actions-can-now-run-in-a-node-js-16-runtime/ As a result, actions authors who move from targeting Node.js 12 to Node.js 16 should release with a new major version number to communicate that there is a possible breaking change for GitHub Enterprise Server 3.3 and earlier.

it was recommended previously by Github to bump major version, thus changed package version to 3.0.0. Let me know if this needs to be changed