### PR TITLE
Upgrade to packer v1.14.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # see https://hub.docker.com/r/hashicorp/packer/tags for all available tags
-FROM hashicorp/packer:light@sha256:1e298ef74fc816654238f7c17ea0f0636c2e19d3baf77ed5f795b7f976a4ba96
+# The following is hashicorp/packer:light-1.14.1
+FROM hashicorp/packer:light@sha256:0bd39e557562cd3af4f596adb30a9c5b32b46d4a62c301e5a78f507e31610625
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 


### PR DESCRIPTION
According to [1], this version should retrieve the `amazon` plugin from
its new location on `releases.hashicorp.com`.

1: https://discuss.hashicorp.com/t/important-update-official-packer-plugin-distribution-moving-to-releases-hashicorp-com/75972

Implements https://turnitin.atlassian.net/browse/DEVOPS-20763
