### PR TITLE
Remove copyright holder from .copywrite.hcl

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -5,7 +5,6 @@ schema_version = 1
 
 project {
     license          = "Apache-2.0"
-    copyright_holder = "HashiCorp, Inc."
     copyright_year   = 2022
 
     header_ignore = [


### PR DESCRIPTION
Removing the `copyright holder` flag from the copyright file to make it in accordance of the standard required as asked by the Compliance team.