### PR TITLE
Updates undici override to 6.24.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -624,9 +624,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
-      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "typescript": "^5.5.4"
   },
   "overrides": {
-    "undici": "6.24.0"
+    "undici": "6.24.1"
   }
 }


### PR DESCRIPTION
Aligns dependency override with the latest undici patch release to incorporate bug fixes and improvements from upstream.